### PR TITLE
Fixing sql compatibility

### DIFF
--- a/migrations/versions/1_init.py
+++ b/migrations/versions/1_init.py
@@ -22,7 +22,7 @@ def upgrade():
         "accounts",
         sa.Column("account_id", sa.Integer(), nullable=False),
         sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=True
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True
         ),
         sa.PrimaryKeyConstraint("account_id"),
     )
@@ -40,7 +40,7 @@ def upgrade():
         sa.Column("password_hash", sa.String(length=128), nullable=False),
         sa.Column("confirmed", sa.Boolean(), server_default="false", nullable=False),
         sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=False
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
         ),
         sa.Column("account_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(
@@ -57,7 +57,7 @@ def upgrade():
         sa.Column(
             "assigned_at",
             sa.DateTime(),
-            server_default=sa.func.current_timestamp(),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.ForeignKeyConstraint(

--- a/migrations/versions/1_init.py
+++ b/migrations/versions/1_init.py
@@ -22,7 +22,7 @@ def upgrade():
         "accounts",
         sa.Column("account_id", sa.Integer(), nullable=False),
         sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+            "created_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=True
         ),
         sa.PrimaryKeyConstraint("account_id"),
     )
@@ -40,7 +40,7 @@ def upgrade():
         sa.Column("password_hash", sa.String(length=128), nullable=False),
         sa.Column("confirmed", sa.Boolean(), server_default="false", nullable=False),
         sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+            "created_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=False
         ),
         sa.Column("account_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(
@@ -57,7 +57,7 @@ def upgrade():
         sa.Column(
             "assigned_at",
             sa.DateTime(),
-            server_default=sa.text("now()"),
+            server_default=sa.func.current_timestamp(),
             nullable=False,
         ),
         sa.ForeignKeyConstraint(


### PR DESCRIPTION
This fixes if you want to use SQLite. This is cross-db version of what it did.

In SQLite this sis transformed to supporter `CURRENT_TIMESTAMP` template, when in PG it will become `now()`

Also, as a suggestion, you can change test URLs to use SQLite, so this just works out of the box. But this is up to you. PR is just to fix obvious bug..